### PR TITLE
chore: upgrade Node.js runtime from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,6 @@ outputs:
     description: 'Build result metadata'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
## Summary
- Upgrades GitHub Actions Node.js runtime from `node20` to `node24`
- Node.js 20 is being deprecated by GitHub Actions (June 2026 warning, Fall 2026 hard block)
- No upstream sync -- customizations preserved as-is

## Test plan
- [ ] Verify action works in a test workflow with Node 24 runtime

Made with [Cursor](https://cursor.com)